### PR TITLE
Workflows documentation correct create a migration plan command

### DIFF
--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -21,7 +21,7 @@ All the commands should be run on Pulp 3 machine.
 .. code:: bash
 
     $ # migrate content for Pulp 2 ISO plugin
-    $ pulp migration plan create plan='{"plugins": [{"type": "iso"}]}'
+    $ pulp migration plan create --plan='{"plugins": [{"type": "iso"}]}'
     {
       "pulp_href": "/pulp/api/v3/migration-plans/8d8d49ee-a754-4a6a-aa7a-d8de4d1039c2/",
       "pulp_created": "2021-02-13T14:20:15.678368Z",


### PR DESCRIPTION
Correct a defect in the documented command to create a migration plan.
This pull request was requested by Matthias Dellweg
https://listman.redhat.com/archives/pulp-list/2021-May/msg00002.html